### PR TITLE
Use multistage builds for docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Django",
-    "dockerComposeFile": "../docker/docker-compose.yml",
+    "dockerComposeFile": ["../docker/docker-compose.yml", "docker-compose.yml"],
     "workspaceFolder": "/workspaces",
     "forwardPorts": [8000],
     "mounts": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,5 @@
+version: '3.4'
+services:
+    web:
+      build:
+        target: development

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,16 @@
-FROM mcr.microsoft.com/devcontainers/python:0-3.11
-
+FROM mcr.microsoft.com/devcontainers/python:0-3.11 AS production
+WORKDIR /app
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get upgrade -y && \
     pip install --upgrade pip && \
     pip install -r requirements.txt && \
-    pip install -r requirements-dev.txt && \
     rm requirements.txt
 
 CMD ["sleep", "infinity"]
+
+
+FROM production AS development
+COPY requirements-dev.txt .
+RUN pip install -r requirements-dev.txt && \
+    rm requirements-dev.txt

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,10 @@
-version: '3.2'
+version: '3.4'
 services:
     web:
       build:
         context: ..
         dockerfile: docker/Dockerfile
+        target: production
 
       expose:
         - 8000


### PR DESCRIPTION
Use multistage builds to separate the containers of production and development. The production doesn't need all the packages.