### PR TITLE
Add test to make sure newly added bloggers gets right permissions

### DIFF
--- a/blognevis/author/tests.py
+++ b/blognevis/author/tests.py
@@ -1,3 +1,24 @@
-# from django.test import TestCase
+from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from blognevis.core.constants import BLOGGERS_ADMINSITE_GROUP
+from .models import Author
+
+
+class AuthorTests(TestCase):
+    def test_authors_get_proper_permissions_when_added_via_adminsite(self):
+        admin = Author.objects.create_superuser("admin", "admin@blognevis.ca", "123")
+        self.client.force_login(admin)
+        self.client.post(
+            reverse("admin:author_author_add"),
+            data={
+                "username": "writer1",
+                "password1": "A2Z-auto",
+                "password2": "A2Z-auto",
+            },
+        )
+
+        # make sure created blogger can login and is added to the bloggers group
+        user = Author.objects.get(username="writer1")
+        self.assertTrue(user.is_staff)
+        user.groups.get(name=BLOGGERS_ADMINSITE_GROUP)


### PR DESCRIPTION
Make sure when users are added via admin site, they automatically get `is_staff=True` and assigned to the Group named Bloggers.