### PR TITLE
Override User model instance/queryset delete() methods

### DIFF
--- a/blognevis/author/models.py
+++ b/blognevis/author/models.py
@@ -1,10 +1,17 @@
-from utility.models import TimeStampedSoftDeleteUUIDMixin, SoftDeleteManager
+from utility.models import TimeStampedSoftDeleteUUIDMixin, UserSoftDeleteQuerySet
 from django.contrib.auth.models import AbstractUser, UserManager
 
 
-class AuthorManager(UserManager, SoftDeleteManager):
+# Here we have custome manager of User class by django. But also want to have a custome queryset
+# that does a soft delete by setting is_active=False. We use this technique:
+# https://docs.djangoproject.com/en/4.1/topics/db/managers/#from-queryset
+class AuthorManager(UserManager.from_queryset(UserSoftDeleteQuerySet)):
     pass
 
 
 class Author(AbstractUser, TimeStampedSoftDeleteUUIDMixin):
     objects = AuthorManager()
+
+    def delete(self, using=None, keep_parents=False):
+        self.is_active = False
+        self.save(update_fields=["is_active"])

--- a/blognevis/author/tests.py
+++ b/blognevis/author/tests.py
@@ -22,3 +22,15 @@ class AuthorTests(TestCase):
         user = Author.objects.get(username="writer1")
         self.assertTrue(user.is_staff)
         user.groups.get(name=BLOGGERS_ADMINSITE_GROUP)
+
+    def test_author_instance_soft_delete(self):
+        user = Author.objects.create_user("ali")
+        user.delete()
+        user.refresh_from_db()
+        self.assertFalse(user.is_active)
+
+    def test_author_queryset_soft_delete(self):
+        user = Author.objects.create_user("ali")
+        Author.objects.filter(username="ali").delete()
+        user.refresh_from_db()
+        self.assertFalse(user.is_active)

--- a/utility/models.py
+++ b/utility/models.py
@@ -4,6 +4,15 @@ from django_softdelete.mangers import SoftDeleteManager  # noqa
 import uuid
 
 
+# ------------------- QuerySets
+class UserSoftDeleteQuerySet(models.QuerySet):
+    def delete(self):
+        # We don't delete users, just set is_active=False, as suggested in:
+        # https://docs.djangoproject.com/en/4.1/ref/contrib/auth/#django.contrib.auth.models.User.is_active
+        return self.update(is_active=False)
+
+
+# ------------------- Models
 class UUIDPrimaryKeyMixin(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
@@ -19,9 +28,7 @@ class TimeStampedMixin(models.Model):
         abstract = True
 
 
-class TimeStampedSoftDeleteUUIDMixin(
-    SoftDeleteModel, TimeStampedMixin, UUIDPrimaryKeyMixin
-):
+class TimeStampedSoftDeleteUUIDMixin(SoftDeleteModel, TimeStampedMixin, UUIDPrimaryKeyMixin):
     _soft_delete_cascade = True
     _restore_soft_deleted_related_objects = True
 


### PR DESCRIPTION
We override the delete() methods on model instance and queryset of User model to set is_active=False on delete. So we basically do a soft delete this way. This is also recommended in djano docs: https://docs.djangoproject.com/en/4.1/ref/contrib/auth/#django.contrib.auth.models.User.is_active