### PR TITLE
Automatically set the author of post when adding a post via admin site

### DIFF
--- a/blognevis/author/factories.py
+++ b/blognevis/author/factories.py
@@ -8,7 +8,6 @@ class BloggerFactory(DjangoModelFactory):
     class Meta:
         model = "author.Author"
 
-    # is_active = True
     is_staff = True
     first_name = "ali"
     last_name = "rosta"

--- a/blognevis/author/factories.py
+++ b/blognevis/author/factories.py
@@ -1,0 +1,25 @@
+from django.contrib.auth.models import Group
+from factory.django import DjangoModelFactory
+
+from blognevis.core.constants import BLOGGERS_ADMINSITE_GROUP
+
+
+class BloggerFactory(DjangoModelFactory):
+    class Meta:
+        model = "author.Author"
+
+    # is_active = True
+    is_staff = True
+    first_name = "ali"
+    last_name = "rosta"
+    email = "ali@email.com"
+
+    @classmethod
+    def create(cls, **kwargs):
+        # override this method to set the many to many relation (groups) after instance is created
+        groups = kwargs.pop("groups", {})
+        user = super().create(**kwargs)
+        group_queryset = Group.objects.filter(name__in={*groups, BLOGGERS_ADMINSITE_GROUP})
+        user.groups.set(group_queryset)
+
+        return user

--- a/blognevis/post/admin.py
+++ b/blognevis/post/admin.py
@@ -6,7 +6,6 @@ from .models import Post
 
 @admin.register(Post)
 class PostAdmin(BlogNevisAdmin):
-    raw_id_fields = ["author"]
     fieldsets = [
         (None, {"fields": ("id",)}),
         ("Post content", {"fields": ("author", "title", "text")}),
@@ -20,3 +19,7 @@ class PostAdmin(BlogNevisAdmin):
             return qs
         # Authors should only see/edit their own posts
         return qs.filter(author=request.user)
+
+    def save_model(self, request, obj, form, change):
+        obj.author = request.user
+        obj.save()

--- a/blognevis/post/admin.py
+++ b/blognevis/post/admin.py
@@ -6,9 +6,10 @@ from .models import Post
 
 @admin.register(Post)
 class PostAdmin(BlogNevisAdmin):
+
     fieldsets = [
         (None, {"fields": ("id",)}),
-        ("Post content", {"fields": ("author", "title", "text")}),
+        ("Post content", {"fields": ("title", "text")}),
         ("Timestamps", {"fields": ("created", "modified")}),
         ("Soft delete status", {"fields": ("is_deleted", "deleted_at")}),
     ]

--- a/blognevis/post/tests.py
+++ b/blognevis/post/tests.py
@@ -20,5 +20,4 @@ class PostAdminViewTests(TestCase):
             },
         )
 
-        # only sent title/text through form data, but the author should automatically be set
         Post.objects.get(title="django", text="blah", author=self.blogger)

--- a/blognevis/post/tests.py
+++ b/blognevis/post/tests.py
@@ -1,3 +1,24 @@
-# from django.test import TestCase
+from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from blognevis.author.factories import BloggerFactory
+from .models import Post
+
+
+class PostAdminViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.blogger = BloggerFactory()
+
+    def test_author_set_automatically_when_creating_post_via_adminsite(self):
+        self.client.force_login(self.blogger)
+        self.client.post(
+            reverse("admin:post_post_add"),
+            data={
+                "title": "django",
+                "text": "blah",
+            },
+        )
+
+        # only sent title/text through form data, but the author should automatically be set
+        Post.objects.get(title="django", text="blah", author=self.blogger)


### PR DESCRIPTION
The authors create posts through admin site. Here we'll automatically set the author of post to the user (and for post create form we only show a title/body input boxes to the user).